### PR TITLE
setting zip safe flag to false

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(
   extras_require = {
     'snappy': ['python-snappy'],
   },
+  zip_safe=False,
 )


### PR DESCRIPTION
Currently no zip flag is set. So setuptools decides (looking at code and making guess) whether to install as egg or folder. On windows it install it as `egg` when called from a third party's setup file and that cause a error. So force set it to false